### PR TITLE
fix: Add hyperlink to discord profile

### DIFF
--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -27,8 +27,8 @@ const socials: Social[] = [
     },
     {
         name: "discord",
-        href: "@_mini.dev",
-        isLink: false,
+        href: "https://discord.com/users/1108024311975002212",
+        isLink: true,
     },
 ];
 

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -20,7 +20,14 @@ import { Icon } from "astro-icon/components";
                 >
                     <span>discord</span>
                     <Icon name="ph:arrow-right" class="size-4 text-txt" />
-                    <span>@_mini.dev</span>
+                    <span>
+                        <a
+                            href="https://discord.com/users/1108024311975002212"
+                            class="hover:underline underline-offset-4"
+                        >
+                            @_mini.dev
+                        </a>
+                    </span>
                 </div>
                 <div
                     class="flex items-center gap-2 text-lg md:text-xl text-txt-0 font-secondary"


### PR DESCRIPTION
Replaced the static discord username with a clickable link to the discord profile in the  `/about` and `/contact` pages.